### PR TITLE
chore(ci-release): tag-triggered GitHub Release + release docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, develop ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ main ]
   workflow_dispatch:
@@ -273,7 +275,7 @@ jobs:
     name: Release Build
     runs-on: macos-latest
     needs: [java-tests, integration-tests, lua-shell-tests, quality-checks]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || startsWith(github.ref, 'refs/tags/v')
     
     steps:
     - uses: actions/checkout@v4
@@ -314,6 +316,18 @@ jobs:
         name: release-bundle
         path: macos-ptt-dictation-release.tar.gz
         retention-days: 30
+    
+    - name: Create GitHub Release (on tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: false
+        prerelease: false
+        files: |
+          macos-ptt-dictation-release.tar.gz
+          whisper-post-processor/dist/whisper-post.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Status check - Required for branch protection
   status:

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -1,45 +1,64 @@
-# Release process
+# Release Process
 
-Personal project friendly, minimal ceremony, reproducible.
-
-## Prepare
-- Ensure README and tests/README are accurate
-- Create ptt_config.lua.sample with safe defaults (LOG_ENABLED=false)
-- Confirm no personal data in repo (logs, symlinks to local audio)
-
-## Development workflow
-- Branch per feature: 'feature/auto-mode-switch', 'feature/ui-overlay', etc.
-- Keep commits small and focused; reference the area in the subject, e.g., 'ptt:', 'ui:', 'refine:'
-- Open a PR even for personal repos to get a clean diff and checklist
+This document defines the formal process to cut a VoxCore release and update a local system.
 
 ## Versioning
-- Update CHANGELOG.md under a new heading (e.g., v0.1.1)
-- Tag and push:
-  git tag -a v0.1.1 -m "<short summary>"
-  git push origin v0.1.1
+- Use semver-like tags: vMAJOR.MINOR.PATCH (e.g., v0.4.1)
+- Patch: bug fixes / non-breaking changes
+- Minor: new features (backward compatible)
+- Major: breaking changes (requires migration notes)
 
-## Pre-release checklist
-- Smoke: short clip and long clip succeed; paste behavior matches policy
-- If refine enabled: verify a short and long refine, and one timeout path
-- Logs: confirm 'auto_mode_decision' and 'paste_decision' entries look correct
+## Automated Releases (preferred)
 
-## GitHub Release
-- Create a release from the tag
-- Include highlights, known issues, and upgrade notes
+Trigger: push a tag matching v*.*.* to origin
 
-## Optional: Homebrew Tap (later)
-- Create repo: cliffmin/homebrew-tap
-- Add formula macos-ptt-dictation.rb (see dist/HomebrewFormula)
-- Users then run two separate commands:
-  brew tap cliffmin/tap
-  brew install macos-ptt-dictation
+1) Ensure main is green
+   - CI must pass on main before tagging
 
-## Optional: VoxCompose release
-- In voxcompose repo: build shaded jar and attach to GitHub Release
-- Provide a tiny launcher script named 'voxcompose' in PATH
-- Optional tap formula (voxcompose.rb)
+2) Tag and push
+```bash
+git checkout main
+git pull
+git tag -a v0.4.1 -m "VoxCore v0.4.1"
+git push origin v0.4.1
+```
 
-## Rollback
-- Checkout the last good tag, e.g., 'git checkout v0.1.0'
-- Re-run the smoke tests
-- If needed, cut a hotfix tag 'v0.1.1'
+3) CI builds and publishes a GitHub Release automatically
+   - Artifacts:
+     - macos-ptt-dictation-release.tar.gz (bundle)
+     - whisper-post-processor/dist/whisper-post.jar
+
+4) Add release notes (optional but recommended)
+   - Edit the GitHub Release to include highlights, changes, and migration notes
+
+## Manual Release (fallback)
+
+1) Merge PR to main and wait for CI
+2) Download the release-bundle artifact from the Release job
+3) Create a GitHub Release manually and attach artifacts
+
+## Local Update (developer machine)
+
+Option A: Update from source
+```bash
+# from repo root
+git checkout main
+git pull
+make build-java
+./scripts/setup/install.sh
+# Reload Hammerspoon
+```
+
+Option B: Update from GitHub Release
+```bash
+# Download release tarball from GitHub Releases
+tar -xzf macos-ptt-dictation-release.tar.gz
+cd release
+./scripts/setup/install.sh
+# Reload Hammerspoon
+```
+
+## Additional Notes
+- Homebrew formula (dist/HomebrewFormula) remains macos-ptt-dictation until repo rename; will migrate to voxcore formula later
+- Ensure README and WARP.md remain accurate after user-visible changes
+- Add CHANGELOG and migration notes for behavior changes


### PR DESCRIPTION
- Add tag trigger (v*.*.*) to CI; publish GitHub Release with artifacts on tag push
- Formalize release-process in docs/development/release-process.md (automated + manual + local update)

After merge:
- To release: git tag -a v0.4.1 -m "VoxCore v0.4.1" && git push origin v0.4.1
- The workflow will build artifacts and create the GitHub Release automatically.
