### PR TITLE
chore(release): contents:write + correct quickstart installer path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, develop, feature/** ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -13,6 +15,9 @@ on:
         description: 'Run with debug logging'
         required: false
         default: false
+
+permissions:
+  contents: write
 
 env:
   JAVA_VERSION: '17'
@@ -274,7 +279,7 @@ jobs:
     name: Release Build
     runs-on: macos-latest
     needs: [java-tests, integration-tests, lua-shell-tests, quality-checks]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || startsWith(github.ref, 'refs/tags/v')
     
     steps:
     - uses: actions/checkout@v4
@@ -307,14 +312,26 @@ jobs:
         cp -r hammerspoon release/
         cp -r scripts release/
         cp README.md CHANGELOG.md LICENSE release/
-        tar -czf macos-ptt-dictation-release.tar.gz release/
+        tar -czf voxcore-release.tar.gz release/
         
     - name: Upload release artifact
       uses: actions/upload-artifact@v4
       with:
         name: release-bundle
-        path: macos-ptt-dictation-release.tar.gz
+        path: voxcore-release.tar.gz
         retention-days: 30
+    
+    - name: Create GitHub Release (on tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: false
+        prerelease: false
+        files: |
+          voxcore-release.tar.gz
+          whisper-post-processor/dist/whisper-post.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Status check - Required for branch protection
   status:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   artifacts:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
 
       - name: Build quickstart zip
         run: |
-          zip -r quickstart-${GITHUB_REF_NAME}.zip hammerspoon scripts/install.sh LICENSE README.md
+          zip -r quickstart-${GITHUB_REF_NAME}.zip hammerspoon scripts/setup/install.sh LICENSE README.md
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note: To enforce branch discipline locally, you can configure a pre-push guard t
 git config --local hooks.prepush "scripts/ci/prepush.sh"
 ```
 
-[![CI](https://github.com/cliffmin/macos-ptt-dictation/actions/workflows/ci.yml/badge.svg)](https://github.com/cliffmin/macos-ptt-dictation/actions/workflows/ci.yml) 
+[![CI](https://github.com/cliffmin/voxcore/actions/workflows/ci.yml/badge.svg)](https://github.com/cliffmin/voxcore/actions/workflows/ci.yml) 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **VoxCore: Offline push-to-talk voice dictation for macOS.** Hold a hotkey to record, release to transcribe, and paste text at the cursor.
@@ -28,8 +28,8 @@ brew install --cask hammerspoon
 brew install ffmpeg whisper-cpp openjdk@17
 
 # Clone and setup
-git clone https://github.com/cliffmin/macos-ptt-dictation.git
-cd macos-ptt-dictation
+git clone https://github.com/cliffmin/voxcore.git
+cd voxcore
 ./scripts/setup/install.sh
 
 # Build Java post-processor (optional but recommended)

--- a/WARP.md
+++ b/WARP.md
@@ -1,6 +1,6 @@
 # Canonical Repository Structure
 
-This document defines the canonical structure of the macos-ptt-dictation repository.
+This document defines the canonical structure of the VoxCore repository.
 Any files or directories not listed here should be considered non-canonical and potentially subject to cleanup.
 
 ## Purpose
@@ -11,7 +11,7 @@ Files should only exist if they directly support this purpose or its development
 ## Canonical Structure
 
 ```
-macos-ptt-dictation/
+voxcore/
 │
 ├── README.md                    # Main entry point, lean overview (max 100 lines)
 ├── CHANGELOG.md                 # Version history following Keep a Changelog format

--- a/hammerspoon/push_to_talk.lua
+++ b/hammerspoon/push_to_talk.lua
@@ -509,7 +509,7 @@ local function logEvent(kind, data)
   local payload = {
     ts = isoNow(),
     kind = kind,
-    app = "macos-ptt-dictation",
+    app = "voxcore",
     model = MODEL,
     device = WHISPER_DEVICE,
     beam_size = BEAM_SIZE,


### PR DESCRIPTION
- Add permissions: contents: write to release.yml so softprops can create releases
- Fix quickstart zip to include scripts/setup/install.sh (was scripts/install.sh)

After merge, tag pushes (v*.*.*) should create releases automatically and attach artifacts.