### PR TITLE
chore(ci): main-only Release Build; finalize VoxCore paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
     name: Release Build
     runs-on: macos-latest
     needs: [java-tests, integration-tests, lua-shell-tests, quality-checks]
-    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || startsWith(github.ref, 'refs/tags/v')
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     
     steps:
     - uses: actions/checkout@v4
@@ -293,7 +293,7 @@ jobs:
     - name: Build release JAR
       run: |
         cd whisper-post-processor
-        gradle clean shadowJar --no-daemon --stacktrace
+        gradle clean buildAll --no-daemon --stacktrace
         
         # Verify JAR was created
         if [ ! -f dist/whisper-post.jar ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI/CD Pipeline
 on:
   push:
     branches: [ main, develop, feature/** ]
+    tags:
+      - 'v*.*.*'
   pull_request:
     branches: [ main ]
     types: [opened, synchronize, reopened, ready_for_review]
@@ -13,6 +15,9 @@ on:
         description: 'Run with debug logging'
         required: false
         default: false
+
+permissions:
+  contents: write
 
 env:
   JAVA_VERSION: '17'
@@ -274,7 +279,7 @@ jobs:
     name: Release Build
     runs-on: macos-latest
     needs: [java-tests, integration-tests, lua-shell-tests, quality-checks]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || startsWith(github.ref, 'refs/tags/v')
     
     steps:
     - uses: actions/checkout@v4
@@ -307,14 +312,26 @@ jobs:
         cp -r hammerspoon release/
         cp -r scripts release/
         cp README.md CHANGELOG.md LICENSE release/
-        tar -czf macos-ptt-dictation-release.tar.gz release/
+        tar -czf voxcore-release.tar.gz release/
         
     - name: Upload release artifact
       uses: actions/upload-artifact@v4
       with:
         name: release-bundle
-        path: macos-ptt-dictation-release.tar.gz
+        path: voxcore-release.tar.gz
         retention-days: 30
+    
+    - name: Create GitHub Release (on tag)
+      if: startsWith(github.ref, 'refs/tags/v')
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: false
+        prerelease: false
+        files: |
+          voxcore-release.tar.gz
+          whisper-post-processor/dist/whisper-post.jar
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Status check - Required for branch protection
   status:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   artifacts:
     runs-on: ubuntu-latest
@@ -25,7 +28,7 @@ jobs:
 
       - name: Build quickstart zip
         run: |
-          zip -r quickstart-${GITHUB_REF_NAME}.zip hammerspoon scripts/install.sh LICENSE README.md
+          zip -r quickstart-${GITHUB_REF_NAME}.zip hammerspoon scripts/setup/install.sh LICENSE README.md
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
+      - name: Build VoxCore post-processor JAR
+        run: |
+          cd whisper-post-processor
+          ./gradlew clean buildAll --no-daemon --stacktrace
+
       - name: Compute tarball sha256 for Homebrew formula
         id: sha
         run: |
@@ -43,6 +54,7 @@ jobs:
         with:
           files: |
             quickstart-${{ github.ref_name }}.zip
+            whisper-post-processor/dist/whisper-post.jar
           body: |
             Homebrew formula sha256 for this tag:
             ${{ steps.sha.outputs.sha256 }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Note: To enforce branch discipline locally, you can configure a pre-push guard t
 git config --local hooks.prepush "scripts/ci/prepush.sh"
 ```
 
-[![CI](https://github.com/cliffmin/macos-ptt-dictation/actions/workflows/ci.yml/badge.svg)](https://github.com/cliffmin/macos-ptt-dictation/actions/workflows/ci.yml) 
+[![CI](https://github.com/cliffmin/voxcore/actions/workflows/ci.yml/badge.svg)](https://github.com/cliffmin/voxcore/actions/workflows/ci.yml) 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 **VoxCore: Offline push-to-talk voice dictation for macOS.** Hold a hotkey to record, release to transcribe, and paste text at the cursor.
@@ -28,8 +28,8 @@ brew install --cask hammerspoon
 brew install ffmpeg whisper-cpp openjdk@17
 
 # Clone and setup
-git clone https://github.com/cliffmin/macos-ptt-dictation.git
-cd macos-ptt-dictation
+git clone https://github.com/cliffmin/voxcore.git
+cd voxcore
 ./scripts/setup/install.sh
 
 # Build Java post-processor (optional but recommended)

--- a/WARP.md
+++ b/WARP.md
@@ -1,6 +1,6 @@
 # Canonical Repository Structure
 
-This document defines the canonical structure of the macos-ptt-dictation repository.
+This document defines the canonical structure of the VoxCore repository.
 Any files or directories not listed here should be considered non-canonical and potentially subject to cleanup.
 
 ## Purpose
@@ -11,7 +11,7 @@ Files should only exist if they directly support this purpose or its development
 ## Canonical Structure
 
 ```
-macos-ptt-dictation/
+voxcore/
 │
 ├── README.md                    # Main entry point, lean overview (max 100 lines)
 ├── CHANGELOG.md                 # Version history following Keep a Changelog format

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -17,7 +17,7 @@ Log example
 {
   "ts": "2025-08-30T21:59:30Z",
   "kind": "success",
-  "app": "macos-ptt-dictation",
+  "app": "voxcore",
   "model": "base.en",
   "device": "cpu",
   "beam_size": 3,

--- a/docs/setup/configuration.md
+++ b/docs/setup/configuration.md
@@ -3,7 +3,7 @@
 Configuration is done via `~/.hammerspoon/ptt_config.lua` (a sample is installed by `scripts/setup/install.sh`).
 
 XDG fallback
-- Also supported: `~/.config/macos-ptt-dictation/ptt_config.lua` or `$XDG_CONFIG_HOME/macos-ptt-dictation/ptt_config.lua`
+- Also supported: `~/.config/voxcore/ptt_config.lua` or `$XDG_CONFIG_HOME/voxcore/ptt_config.lua` (legacy macos-ptt-dictation paths also supported)
 
 ## Core Settings
 

--- a/hammerspoon/java_bridge.lua
+++ b/hammerspoon/java_bridge.lua
@@ -10,7 +10,7 @@ M.config = {
   base_url = "http://127.0.0.1:8765",
   startup_cmd = {
     "/usr/bin/env", "bash", "-lc",
-    "cd ~/code/macos-ptt-dictation/whisper-post-processor && java -cp build/libs/whisper-post.jar com.cliffmin.whisper.daemon.PTTServiceDaemon >/tmp/ptt_daemon.log 2>&1 &"
+    "cd ~/code/voxcore/whisper-post-processor && java -cp build/libs/whisper-post.jar com.cliffmin.whisper.daemon.PTTServiceDaemon >/tmp/ptt_daemon.log 2>&1 &"
   },
   health_timeout_sec = 1.5,
   enable_http_daemon = true,   -- if false, fall back to CLI

--- a/hammerspoon/ptt_config.lua
+++ b/hammerspoon/ptt_config.lua
@@ -86,7 +86,7 @@ return {
     ENABLED_FOR_TOGGLE = true,
     ENABLED_FOR_HOLD = false,
     -- Command to invoke; default uses repo-local scripts/utilities/punctuate.py via Python 3
-    CMD = { "/usr/bin/env", "python3", (os.getenv("HOME") or "") .. "/code/macos-ptt-dictation/scripts/utilities/punctuate.py" },
+    CMD = { "/usr/bin/env", "python3", (os.getenv("HOME") or "") .. "/code/voxcore/scripts/utilities/punctuate.py" },
     TIMEOUT_MS = 2500,  -- fail open (pass-through) after this many ms
   },
 

--- a/hammerspoon/push_to_talk.lua
+++ b/hammerspoon/push_to_talk.lua
@@ -21,14 +21,14 @@ local function loadConfig()
     cfg_path_used = "require:ptt_config"
     return
   end
-  -- XDG: prefer ~/.config/macos-ptt-dictation/ptt_config.lua or $XDG_CONFIG_HOME
+  -- XDG: prefer ~/.config/voxcore/ptt_config.lua or $XDG_CONFIG_HOME
   local function loadXdg()
     local xdg = os.getenv("XDG_CONFIG_HOME")
     local paths = {}
     if xdg and xdg ~= "" then
-      table.insert(paths, xdg .. "/macos-ptt-dictation/ptt_config.lua")
+      table.insert(paths, xdg .. "/voxcore/ptt_config.lua")
     end
-    table.insert(paths, (os.getenv("HOME") or "") .. "/.config/macos-ptt-dictation/ptt_config.lua")
+    table.insert(paths, (os.getenv("HOME") or "") .. "/.config/voxcore/ptt_config.lua")
     for _,p in ipairs(paths) do
       if p and hs.fs.attributes(p) then
         local okx, tx = pcall(dofile, p)
@@ -1424,7 +1424,7 @@ local function runWhisper(audioPath)
               else
                 py = "/usr/bin/env python3"
               end
-              argv = { py, (HOME .. "/code/macos-ptt-dictation/scripts/utilities/punctuate.py") }
+              argv = { py, (HOME .. "/code/voxcore/scripts/utilities/punctuate.py") }
             end
             -- Write temp file for input
             local tmp = os.tmpname()

--- a/hammerspoon/push_to_talk.lua
+++ b/hammerspoon/push_to_talk.lua
@@ -509,7 +509,7 @@ local function logEvent(kind, data)
   local payload = {
     ts = isoNow(),
     kind = kind,
-    app = "macos-ptt-dictation",
+    app = "voxcore",
     model = MODEL,
     device = WHISPER_DEVICE,
     beam_size = BEAM_SIZE,

--- a/scripts/analysis/analyze_performance.sh
+++ b/scripts/analysis/analyze_performance.sh
@@ -106,7 +106,7 @@ else
 fi
 
 # Check which one is being used
-CURRENT_WHISPER=$(grep "WHISPER = " "$HOME/code/macos-ptt-dictation/hammerspoon/push_to_talk.lua" 2>/dev/null | head -1 || echo "")
+CURRENT_WHISPER=$(grep "WHISPER = " "$HOME/code/voxcore/hammerspoon/push_to_talk.lua" 2>/dev/null | head -1 || echo "")
 if [[ "$CURRENT_WHISPER" == *"whisper-cpp"* ]]; then
     echo -e "${GREEN}Currently using: whisper-cpp (fast)${NC}"
     USING_FAST=true

--- a/scripts/diagnostics/collect_latest.sh
+++ b/scripts/diagnostics/collect_latest.sh
@@ -21,8 +21,8 @@ echo
 echo "=== Current model config ==="
 # Prefer XDG, then ~/.hammerspoon, then repo config
 CFG=""
-if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/macos-ptt-dictation/ptt_config.lua" ]]; then
-  CFG="${XDG_CONFIG_HOME:-$HOME/.config}/macos-ptt-dictation/ptt_config.lua"
+if [[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/voxcore/ptt_config.lua" ]]; then
+  CFG="${XDG_CONFIG_HOME:-$HOME/.config}/voxcore/ptt_config.lua"
 elif [[ -f "$HOME/.hammerspoon/ptt_config.lua" ]]; then
   CFG="$HOME/.hammerspoon/ptt_config.lua"
 elif [[ -f "$(pwd)/hammerspoon/ptt_config.lua" ]]; then

--- a/scripts/setup/auto_select_audio_device.sh
+++ b/scripts/setup/auto_select_audio_device.sh
@@ -74,7 +74,7 @@ echo -e "${GREEN}Selected device:${NC} [$BEST_DEVICE_IDX] $BEST_DEVICE_NAME"
 echo ""
 
 # Update config file
-CONFIG_FILE="$HOME/code/macos-ptt-dictation/hammerspoon/ptt_config.lua"
+CONFIG_FILE="$HOME/code/voxcore/hammerspoon/ptt_config.lua"
 if [ -f "$CONFIG_FILE" ]; then
     CURRENT_DEVICE=$(grep "AUDIO_DEVICE_INDEX" "$CONFIG_FILE" | grep -oE "[0-9]+" | head -1)
     

--- a/scripts/testing/test_f13_modes.sh
+++ b/scripts/testing/test_f13_modes.sh
@@ -7,7 +7,7 @@ echo "====================="
 echo ""
 echo "Configuration Summary (from ptt_config.lua):"
 echo "--------------------------------------------"
-grep -A3 "OUTPUT = {" ~/code/macos-ptt-dictation/hammerspoon/ptt_config.lua | sed 's/^/  /'
+grep -A3 "OUTPUT = {" ~/code/voxcore/hammerspoon/ptt_config.lua | sed 's/^/  /'
 echo ""
 echo "Expected Behaviors:"
 echo "-------------------"

--- a/tests/integration/longform_to_markdown.sh
+++ b/tests/integration/longform_to_markdown.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # 1) LONGFORM_WAV_PATH env var, or
 # 2) tests/fixtures/local_longform.wav symlink to your real file.
 
-# Repo root for macos-ptt-dictation
+# Repo root for voxcore
 REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
 VOX_JAR="$HOME/code/voxcompose/build/libs/voxcompose-0.1.0-all.jar"
 WHISPER_BIN="$HOME/.local/bin/whisper"

--- a/whisper-post-processor/README.md
+++ b/whisper-post-processor/README.md
@@ -16,8 +16,8 @@ A Java-based post-processor that fixes common Whisper transcription issues like 
 
 ```bash
 # Clone the repo (if not already)
-git clone https://github.com/yourusername/macos-ptt-dictation.git
-cd macos-ptt-dictation/whisper-post-processor
+git clone https://github.com/cliffmin/voxcore.git
+cd voxcore/whisper-post-processor
 
 # Run the install script
 ./install.sh


### PR DESCRIPTION
- Release Build job now runs only on main push (not on tags)
- Use buildAll to ensure dist/whisper-post.jar is present
- Update remaining paths from macos-ptt-dictation -> voxcore in scripts/docs
