### PR TITLE
chore(core): remove ContextProcessor; keep core stateless; move adaptive casing to VoxCompose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Removed
+- ContextProcessor has been removed from VoxCore (daemon streaming pipeline), aligning with a stateless core. Adaptive/contextual casing moves to VoxCompose. No behavior change to the default CLI path.
+
 ## [0.4.0] - 2025-09-17
 - Java service (HTTP/WS) with configuration and metrics
 - Reliable start-of-speech capture (reduced first-word truncation due to warm service)

--- a/JAVA_CONVERSION_PLAN.md
+++ b/JAVA_CONVERSION_PLAN.md
@@ -154,21 +154,7 @@ public class RealtimeTranscriber {
 - [ ] VAD (Voice Activity Detection)
 
 ### 5.2 Context-Aware Processing
-```java
-package com.cliffmin.whisper.context;
-
-public class ContextProcessor {
-    - loadPreviousTranscriptions(n) -> Context
-    - applyContext(transcription, context) -> Enhanced
-    - learnUserPatterns() -> Model
-}
-```
-
-**Tasks**:
-- [ ] Session context management
-- [ ] User vocabulary learning
-- [ ] Automatic correction patterns
-- [ ] Domain-specific terminology
+Note: Context-aware/adaptive processing (e.g., casing learned from recent text) is out of scope for VoxCore. It belongs in VoxCompose (the refiner) and may export explicit rules to VoxCore dictionaries.
 
 ### 5.3 Performance Monitoring
 ```java

--- a/WARP.md
+++ b/WARP.md
@@ -91,7 +91,7 @@ voxcore/
 │   ├── gradle/               # Gradle wrapper files
 │   ├── src/                  # Java source code
 │   │   ├── main/java/        # Main implementation
-│   │   │   └── processors/   # Text processors (Reflow, Context, Disfluency, Dictionary, etc.)
+│   │   │   │   └── processors/   # Text processors (Reflow, Disfluency, Dictionary, etc.)
 │   │   └── test/java/        # Tests (unit, integration; unit excludes @Tag("integration"))
 │   │       ├── processors/   # Unit tests for each processor
 │   │       └── integration/  # E2E integration tests

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -7,7 +7,7 @@ Overview
   - HTTP: /health, /transcribe, /metrics (Prometheus)
   - WebSocket: /ws (incremental processing of accumulated text)
 - Transcription: whisper.cpp via WhisperService/WhisperCppAdapter
-- Java Post-Processor Pipeline: Reflow → Context → Disfluency → MergedWord → Sentences → Capitalization → PunctuationProcessor → Dictionary → PunctuationNormalizer
+- Java Post-Processor Pipeline: Reflow → Disfluency → MergedWord → Sentences → Capitalization → PunctuationProcessor → Dictionary → PunctuationNormalizer
 - Config precedence: request > env/file (~/.config/ptt-dictation/config.json) > defaults
 - Outputs: pasted text (Hammerspoon), optional files/logs
 - Optional refine: VoxCompose remains supported but Java now covers most cleanup

--- a/whisper-post-processor/src/main/java/com/cliffmin/whisper/daemon/PTTServiceDaemon.java
+++ b/whisper-post-processor/src/main/java/com/cliffmin/whisper/daemon/PTTServiceDaemon.java
@@ -81,7 +81,6 @@ public class PTTServiceDaemon {
         // Streaming WS uses the same processing pipeline as CLI
         var pipeline = new com.cliffmin.whisper.pipeline.ProcessingPipeline();
         pipeline.addProcessor(new com.cliffmin.whisper.processors.ReflowProcessor());
-        pipeline.addProcessor(new com.cliffmin.whisper.context.ContextProcessor(200));
         pipeline.addProcessor(new com.cliffmin.whisper.processors.DisfluencyProcessor());
         pipeline.addProcessor(new com.cliffmin.whisper.processors.MergedWordProcessor());
         pipeline.addProcessor(new com.cliffmin.whisper.processors.SentenceBoundaryProcessor());


### PR DESCRIPTION
Context and scope
- Remove ContextProcessor from VoxCore runtime so the core remains strictly stateless and algorithmic.
- Adaptive/contextual behavior (casing, future word-separation learning) will live in VoxCompose and export explicit rules to VoxCore dictionaries when needed.

What changed
- Daemon streaming pipeline: removed ContextProcessor (no behavior change to default CLI path)
- ContextProcessor class: deprecated to a no-op stub to keep builds green during migration
- Tests: disabled ContextProcessor test with rationale
- Docs: architecture pipeline updated; WARP processors list adjusted
- CHANGELOG: Unreleased notes documenting removal and future direction
- JAVA_CONVERSION_PLAN: mark context-aware processing as VoxCompose scope

Rationale
- Preserve determinism and testability in VoxCore by default
- Keep “smart/adaptive” in VoxCompose (optional refiner), enabling persistence and reviewable promotion to dictionaries