### PR TITLE
build: adopt Gradle Version Catalogs for whisper-post-processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+- build: adopt Gradle Version Catalog for whisper-post-processor dependencies (internal; no user-visible changes)
+
 ### Removed
 - ContextProcessor has been removed from VoxCore (daemon streaming pipeline), aligning with a stateless core. Adaptive/contextual casing moves to VoxCompose. No behavior change to the default CLI path.
 

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -4,6 +4,7 @@
 - [Architecture](architecture.md) - System design and components
 - [Testing](testing.md) - Running tests and adding test cases
 - [Release Process](release-process.md) - How to cut a release
+- [Dependency Policy](dependency-policy.md) - Dependency versioning via Gradle Version Catalogs
 
 ## API Documentation
 - [Refiner Plugin API](../api/refiner-plugin.md) - Integrating AI refiners

--- a/docs/development/dependency-policy.md
+++ b/docs/development/dependency-policy.md
@@ -1,0 +1,31 @@
+# Dependency Version Policy
+
+This project uses a Gradle Version Catalog to pin and manage dependency versions for the Java post-processor.
+
+Scope (current)
+- Module: whisper-post-processor
+- Catalog file: whisper-post-processor/gradle/libs.versions.toml
+- Build script references: whisper-post-processor/build.gradle via libs aliases (e.g., libs.gson, libs.junitJupiter)
+
+Rationale
+- Single source of truth for dependency versions
+- Easier upgrades and conflict resolution
+- Cleaner build.gradle with readable aliases
+
+Upgrade process
+1) Edit whisper-post-processor/gradle/libs.versions.toml
+   - Bump versions under [versions]
+2) Validate locally
+   - ./whisper-post-processor/gradlew -p whisper-post-processor test --no-daemon --console=plain
+3) Open PR
+   - Title: build(whisper-post-processor): bump <dep> to <version>
+   - Include brief notes on changes and links to release notes if relevant
+
+Notes
+- Plugins: The shadow plugin version is currently declared in build.gradle to minimize blast radius. We may migrate plugin versions into the catalog later using [plugins] aliases.
+- CI: No changes required; tests must remain green.
+- Dependabot: Gradle version catalogs are supported; automated PRs may target libs.versions.toml entries.
+
+Troubleshooting
+- If a library adds transitive changes that break tests, consider bumping related test/runtime dependencies together (e.g., JUnit Platform + Jupiter, AssertJ + Mockito).
+- Keep AssertJ, JUnit Jupiter, and JUnit Platform in compatible ranges (see their release notes).

--- a/whisper-post-processor/build.gradle
+++ b/whisper-post-processor/build.gradle
@@ -18,33 +18,33 @@ repositories {
 
 dependencies {
     // CLI framework
-    implementation 'info.picocli:picocli:4.7.5'
+    implementation libs.picocli
     
     // JSON processing
-    implementation 'com.google.code.gson:gson:2.13.2'
+    implementation libs.gson
     
     // String utilities
-    implementation 'org.apache.commons:commons-lang3:3.18.0'
+    implementation libs.commonsLang3
     
     // Logging
-    implementation 'org.slf4j:slf4j-simple:2.0.9'
+    implementation libs.slf4jSimple
 
     // HTTP server for daemon
-    implementation 'io.undertow:undertow-core:2.3.10.Final'
-    implementation 'io.undertow:undertow-websockets-jsr:2.3.10.Final'
+    implementation libs.undertowCore
+    implementation libs.undertowWebsocketsJsr
 
     // Metrics
-    implementation 'io.micrometer:micrometer-core:1.11.5'
-    implementation 'io.micrometer:micrometer-registry-prometheus:1.11.5'
+    implementation libs.micrometerCore
+    implementation libs.micrometerPrometheus
     
     // Testing
-    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.1'
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.1'
-    testImplementation 'org.junit.platform:junit-platform-launcher:1.13.4'
-    testImplementation 'org.junit.platform:junit-platform-suite-api:1.13.4'
-    testImplementation 'org.junit.platform:junit-platform-suite-engine:1.13.4'
-    testImplementation 'org.assertj:assertj-core:3.24.2'
-    testImplementation 'org.mockito:mockito-core:5.11.0'
+    testImplementation libs.junitJupiter
+    testImplementation libs.junitJupiterEngine
+    testImplementation libs.junitPlatformLauncher
+    testImplementation libs.junitPlatformSuiteApi
+    testImplementation libs.junitPlatformSuiteEngine
+    testImplementation libs.assertjCore
+    testImplementation libs.mockitoCore
 }
 
 // Configure JAR manifest

--- a/whisper-post-processor/gradle/libs.versions.toml
+++ b/whisper-post-processor/gradle/libs.versions.toml
@@ -1,0 +1,28 @@
+[versions]
+picocli = "4.7.5"
+gson = "2.13.2"
+commonsLang3 = "3.18.0"
+slf4j = "2.0.9"
+undertow = "2.3.10.Final"
+micrometer = "1.11.5"
+junitJupiter = "5.10.1"
+junitPlatform = "1.13.4"
+assertj = "3.27.4"
+mockito = "5.11.0"
+
+[libraries]
+picocli = { module = "info.picocli:picocli", version.ref = "picocli" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+commonsLang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
+slf4jSimple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+undertowCore = { module = "io.undertow:undertow-core", version.ref = "undertow" }
+undertowWebsocketsJsr = { module = "io.undertow:undertow-websockets-jsr", version.ref = "undertow" }
+micrometerCore = { module = "io.micrometer:micrometer-core", version.ref = "micrometer" }
+micrometerPrometheus = { module = "io.micrometer:micrometer-registry-prometheus", version.ref = "micrometer" }
+junitJupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junitJupiter" }
+junitJupiterEngine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitJupiter" }
+junitPlatformLauncher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junitPlatform" }
+junitPlatformSuiteApi = { module = "org.junit.platform:junit-platform-suite-api", version.ref = "junitPlatform" }
+junitPlatformSuiteEngine = { module = "org.junit.platform:junit-platform-suite-engine", version.ref = "junitPlatform" }
+assertjCore = { module = "org.assertj:assertj-core", version.ref = "assertj" }
+mockitoCore = { module = "org.mockito:mockito-core", version.ref = "mockito" }


### PR DESCRIPTION
This PR introduces a Gradle Version Catalog scoped to the whisper-post-processor module and refactors build.gradle to use catalog aliases.\n\nChanges:\n- build(whisper-post-processor): adopt Version Catalog (gradle/libs.versions.toml)\n- refactor: replace hardcoded dependency coordinates with libs.* aliases\n- docs: add dependency-policy.md and link from docs/development/README.md\n- changelog: note internal build change under Unreleased\n\nNotes:\n- No user-visible behavior changes; tests pass locally\n- Keeps plugin versions in build.gradle to minimize blast radius for now\n\nAfter merge:\n- Dependabot can target libs.versions.toml entries for future bumps